### PR TITLE
[BUGFIX] 채널톡 컴포넌트가 페이지 전환 시 재초기화되지 않는 문제 해결

### DIFF
--- a/src/components/ChannelTalk.jsx
+++ b/src/components/ChannelTalk.jsx
@@ -7,73 +7,84 @@ export default function ChannelTalk() {
 
   const isAuthPage = () => {
     const path = window.location.pathname;
-    return path.startsWith('/admin') || 
-           path.includes('/signin') || 
-           path.includes('/signup');
+    return path.startsWith('/admin') ||
+           path.startsWith('/user/signin') ||
+           path.startsWith('/user/signup');
+  };
+
+  const cleanupChannelTalk = () => {
+    if (window.ChannelIO) {
+      window.ChannelIO('shutdown');
+    }
+    const existingScript = document.querySelector('script[src*="channel.io"]');
+    if (existingScript) {
+      existingScript.remove();
+    }
+    window.ChannelIO = undefined;
+  };
+
+  const initChannelTalk = () => {
+    cleanupChannelTalk();
+
+    if (isAuthPage()) {
+      return;
+    }
+
+    const ch = function() {
+      ch.c(arguments);
+    };
+    ch.q = [];
+    ch.c = function(args) {
+      ch.q.push(args);
+    };
+    window.ChannelIO = ch;
+
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://cdn.channel.io/plugin/ch-plugin-web.js';
+    channelTalkRef.current = script;
+
+    script.onload = () => {
+      if (!window.ChannelIO) return;
+      window.ChannelIO('boot', {
+        "pluginKey": "81010319-9027-4bd0-8c9d-2f19caa0f5d1",
+        "memberId": user?.id || '',
+        "profile": {
+          "name": user?.name || '게스트',
+          "email": user?.email || ''
+        }
+      });
+    };
+
+    document.head.appendChild(script);
   };
 
   useEffect(() => {
-    // 관리자 페이지나 인증 페이지면 초기화하지 않음
-    if (isAuthPage()) return;
-
-    const initChannelTalk = () => {
-      if (window.ChannelIO) {
-        return;
-      }
-
-      const w = window;
-      if (w.ChannelIO) return;
-
-      const ch = function() {
-        ch.c(arguments);
-      };
-      ch.q = [];
-      ch.c = function(args) {
-        ch.q.push(args);
-      };
-      w.ChannelIO = ch;
-
-      const script = document.createElement('script');
-      script.async = true;
-      script.src = 'https://cdn.channel.io/plugin/ch-plugin-web.js';
-      channelTalkRef.current = script;
-
-      script.onload = () => {
-        w.ChannelIO('boot', {
-          "pluginKey": "81010319-9027-4bd0-8c9d-2f19caa0f5d1",
-          "memberId": user?.id,
-          "profile": {
-            "name": user?.name || '게스트',
-            "email": user?.email
-          }
-        });
-      };
-
-      document.head.appendChild(script);
-    };
-
+    // 페이지 로드/새로고침 시 초기화
     initChannelTalk();
 
-    if (window.ChannelIO && user) {
-      window.ChannelIO('updateUser', {
-        "memberId": user.id,
-        "name": user.name,
-        "email": user.email
-      });
-    }
+    // history 변경 감지 (뒤로가기, 앞으로가기, pushState)
+    const handleRouteChange = () => {
+      setTimeout(() => {
+        initChannelTalk();
+      }, 100);
+    };
+
+    window.addEventListener('popstate', handleRouteChange);
+
+    // React Router의 history.push() 감지
+    const originalPushState = window.history.pushState;
+    window.history.pushState = function() {
+      originalPushState.apply(this, arguments);
+      handleRouteChange();
+    };
 
     return () => {
-      if (window.ChannelIO) {
-        window.ChannelIO('shutdown');
-      }
-      if (channelTalkRef.current && channelTalkRef.current.parentNode) {
-        channelTalkRef.current.parentNode.removeChild(channelTalkRef.current);
-      }
+      window.removeEventListener('popstate', handleRouteChange);
+      window.history.pushState = originalPushState;
+      cleanupChannelTalk();
     };
   }, [user]);
-
-  // 관리자 페이지나 인증 페이지면 null 반환
-  if (isAuthPage()) return null;
 
   return null;
 }


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
채널톡 컴포넌트가 페이지 전환 시 재초기화되지 않는 문제 발생
처음에 window.location.pathname(가장 기본적인 방식)를 사용하여  URL의 경로가져와서 shutdown했는데 바로바로 동작을 안했음 
두번째로  MutationObserver(DOM의 변화를 감시하여 URL 변경을 감지하는 방식)를 사용하였는데 버튼 클릭 이벤트로 이동하니 제대로 동작을 안했음
마지막으로 브라우저의 History API를 직접 활용하는 방식를 사용함 
- 실제 라우팅 변경을 정확하게 감지할 수 있음
- SPA의 클라이언트 사이드 라우팅과 완벽하게 동작함
- popstate 이벤트로 브라우저의 뒤로가기/앞으로가기 감지
- pushState 메서드를 오버라이드하여 프로그래밍 방식의 네비게이션 감지
![image](https://github.com/user-attachments/assets/bfdb0160-fdfa-4fc7-b712-92d6b8356c30)
 SPA에서 라우팅 변경을 감지해야 하는 경우, History API를 가장 많이 활용한다고 함 

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #96
