### PR TITLE
[BUGFIX] 카테고리 컴포넌트 뒤로가기 안되는 버그, 페이지 이동 시 채널톡이 깜빡이는 버그 해결

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,10 @@ import { RouterProvider } from "react-router-dom";
 import router from "@/routes";
 import "./assets/css/typography.css";
 import ToastProvider from "@components/Toast";
-import ChannelTalk from "@components/ChannelTalk";
 
 function App() {
   return (
     <>
-      <ChannelTalk /> 
       <ToastProvider />
       <RouterProvider router={router} future={{ v7_startTransition: true }} />
     </>

--- a/src/components/ChannelTalk.jsx
+++ b/src/components/ChannelTalk.jsx
@@ -1,35 +1,14 @@
 import { useEffect, useRef } from 'react';
 import useUserStore from '@zustand/userStore';
+import { useLocation } from 'react-router-dom';
 
-export default function ChannelTalk() {
+function ChannelTalk() {
   const channelTalkRef = useRef(null);
   const user = useUserStore(state => state.user);
+  const location = useLocation();
 
-  const isAuthPage = () => {
-    const path = window.location.pathname;
-    return path.startsWith('/admin') ||
-           path.startsWith('/user/signin') ||
-           path.startsWith('/user/signup');
-  };
-
-  const cleanupChannelTalk = () => {
-    if (window.ChannelIO) {
-      window.ChannelIO('shutdown');
-    }
-    const existingScript = document.querySelector('script[src*="channel.io"]');
-    if (existingScript) {
-      existingScript.remove();
-    }
-    window.ChannelIO = undefined;
-  };
-
-  const initChannelTalk = () => {
-    cleanupChannelTalk();
-
-    if (isAuthPage()) {
-      return;
-    }
-
+  // 채널톡 초기화 함수
+  const initializeChannelTalk = () => {
     const ch = function() {
       ch.c(arguments);
     };
@@ -45,46 +24,43 @@ export default function ChannelTalk() {
     channelTalkRef.current = script;
 
     script.onload = () => {
-      if (!window.ChannelIO) return;
       window.ChannelIO('boot', {
         "pluginKey": "81010319-9027-4bd0-8c9d-2f19caa0f5d1",
         "memberId": user?.id || '',
         "profile": {
           "name": user?.name || '게스트',
           "email": user?.email || ''
-        }
+        },
+        "hideChannelButtonOnBoot": true // 초기 로딩 시 버튼이 잠깐 보였다가 사라지는 것을 방지하기 위한 안전장치로 사용(없어도 됨)
       });
     };
 
     document.head.appendChild(script);
   };
 
+  // 초기화는 한 번만
   useEffect(() => {
-    // 페이지 로드/새로고침 시 초기화
-    initChannelTalk();
+    if (!window.ChannelIO) {
+      initializeChannelTalk();
+    }
+  }, []);
 
-    // history 변경 감지 (뒤로가기, 앞으로가기, pushState)
-    const handleRouteChange = () => {
-      setTimeout(() => {
-        initChannelTalk();
-      }, 100);
-    };
+  // 페이지 변경 감지 및 처리
+  useEffect(() => {
+    const isAuthPage = location.pathname.startsWith('/admin') ||
+                      location.pathname.startsWith('/user/signin') ||
+                      location.pathname.startsWith('/user/signup');
 
-    window.addEventListener('popstate', handleRouteChange);
-
-    // React Router의 history.push() 감지
-    const originalPushState = window.history.pushState;
-    window.history.pushState = function() {
-      originalPushState.apply(this, arguments);
-      handleRouteChange();
-    };
-
-    return () => {
-      window.removeEventListener('popstate', handleRouteChange);
-      window.history.pushState = originalPushState;
-      cleanupChannelTalk();
-    };
-  }, [user]);
+    if (window.ChannelIO) {
+      if (isAuthPage) {
+        window.ChannelIO('hideChannelButton');
+      } else {
+        window.ChannelIO('showChannelButton');
+      }
+    }
+  }, [location.pathname]);
 
   return null;
 }
+
+export default ChannelTalk;

--- a/src/components/layout/Category.jsx
+++ b/src/components/layout/Category.jsx
@@ -4,118 +4,118 @@ import useCodeStore from "../../zustand/codeStore";
 import useAxiosInstance from "@/hooks/useAxiosInstance";
 
 const Category = () => {
- const navigate = useNavigate();
- const location = useLocation();
- const { codes, setCodes } = useCodeStore(); // Zustand에서 codes 상태와 setter 가져오기
- const axios = useAxiosInstance();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { codes, setCodes } = useCodeStore(); // Zustand에서 codes 상태와 setter 가져오기
+  const axios = useAxiosInstance();
 
- // URL에서 현재 카테고리 코드 추출
- const currentCategory = new URLSearchParams(location.search).get("category") || "ALL";
+  // URL에서 현재 카테고리 코드 추출
+  const currentCategory = new URLSearchParams(location.search).get("category") || "ALL";
 
- // 초기 활성 아이템 설정
- const [activeItem, setActiveItem] = useState(
-   currentCategory === "ALL" ? "전체상품" : currentCategory
- );
+  // 초기 활성 아이템 설정
+  const [activeItem, setActiveItem] = useState(
+    currentCategory === "ALL" ? "전체상품" : currentCategory
+  );
 
- // 기본 메뉴 아이템
- const defaultItems = [
-   { name: "전체상품", code: "ALL" },
-   { name: "신상", code: "NEW" },
-   { name: "BEST", code: "BEST" },
- ];
+  // 기본 메뉴 아이템
+  const defaultItems = [
+    { name: "전체상품", code: "ALL" },
+    { name: "신상", code: "NEW" },
+    { name: "BEST", code: "BEST" },
+  ];
 
- // 데이터 가져오기: 컴포넌트가 처음 렌더링될 때 호출
- useEffect(() => {
-   const fetchCodes = async () => {
-     try {
-       const response = await axios.get("/codes/productCategory"); // API 호출
-       const fetchedCodes = response.data.item.productCategory.codes;
+  // 데이터 가져오기: 컴포넌트가 처음 렌더링될 때 호출
+  useEffect(() => {
+    const fetchCodes = async () => {
+      try {
+        const response = await axios.get("/codes/productCategory"); // API 호출
+        const fetchedCodes = response.data.item.productCategory.codes;
 
-       // Zustand에 저장
-       setCodes(fetchedCodes);
-     } catch (error) {
-       console.error("카테고리 데이터를 불러오는 중 오류 발생:", error);
-     }
-   };
+        // Zustand에 저장
+        setCodes(fetchedCodes);
+      } catch (error) {
+        console.error("카테고리 데이터를 불러오는 중 오류 발생:", error);
+      }
+    };
 
-   // Zustand의 codes가 없을 때만 호출
-   if (!codes) {
-     fetchCodes();
-   }
- }, [axios, setCodes, codes]);
-
- // location 변화를 감지하여 activeItem 업데이트
- useEffect(() => {
-  // 홈페이지인 경우
-  if (location.pathname === '/') {
-    setActiveItem(""); 
-    return;
-  }
-
-  // 카테고리 페이지인 경우
-  if (currentCategory === 'ALL') {
-    setActiveItem("전체상품");
-  } else if (currentCategory === 'NEW') {
-    setActiveItem("신상");
-  } else if (currentCategory === 'BEST') {
-    setActiveItem("BEST");
-  } else {
-    // 일반 카테고리의 경우
-    const categoryItem = codes?.find(cat => cat.code === currentCategory);
-    if (categoryItem) {
-      setActiveItem(categoryItem.value);
+    // Zustand의 codes가 없을 때만 호출
+    if (!codes) {
+      fetchCodes();
     }
-  }
-}, [location, currentCategory, codes]);
+  }, [axios, setCodes, codes]);
 
- // 전체 메뉴 아이템 준비
- const menuItems = [
-   ...defaultItems,
-   ...(Array.isArray(codes)
-     ? codes.map((category) => ({
-         name: category.value,
-         code: category.code,
-       }))
-     : []),
- ];
+  // location 변화를 감지하여 activeItem 업데이트
+  useEffect(() => {
+    // 홈페이지인 경우
+    if (location.pathname === '/') {
+      setActiveItem("");
+      return;
+    }
 
- const handleCategoryClick = (item) => {
-   if (!item?.code) return;
+    // 카테고리 페이지인 경우
+    if (currentCategory === 'ALL') {
+      setActiveItem("전체상품");
+    } else if (currentCategory === 'NEW') {
+      setActiveItem("신상");
+    } else if (currentCategory === 'BEST') {
+      setActiveItem("BEST");
+    } else {
+      // 일반 카테고리의 경우
+      const categoryItem = codes?.find(cat => cat.code === currentCategory);
+      if (categoryItem) {
+        setActiveItem(categoryItem.value);
+      }
+    }
+  }, [location, currentCategory, codes]);
 
-   setActiveItem(item.name);
-   const newPath =
-     item.code === "ALL"
-       ? "/list?page=1"
-       : `/list?category=${item.code}&page=1`;
+  // 전체 메뉴 아이템 준비
+  const menuItems = [
+    ...defaultItems,
+    ...(Array.isArray(codes)
+      ? codes.map((category) => ({
+          name: category.value,
+          code: category.code,
+        }))
+      : []),
+  ];
 
-   navigate(newPath, { replace: true });
- };
+  const handleCategoryClick = (item) => {
+    if (!item?.code) return;
 
- return (
-   <nav className="w-full bg-white border-b border-gray-200 overflow-x-auto">
-     <div className="max-w-7xl mx-auto px-4 md:px-6">
-       <div className="flex justify-start items-center h-16 md:h-14">
-         <div className="flex gap-12 md:gap-8 sm:gap-2 whitespace-nowrap">
-           {menuItems.map((item) => (
-             <button
-               key={item.name}
-               className={`relative px-3 py-2 md:py-1.5 text-sm md:text-[15px] sm:text-xs font-medium
-                         transition-colors duration-200 border-0 bg-transparent cursor-pointer shrink-0
-                         ${
-                           activeItem === item.name
-                             ? 'text-yellow-300 after:content-[""] after:absolute after:bottom-[-1px] after:left-0 after:w-full after:h-0.5 after:bg-yellow-300'
-                             : "hover:text-yellow-300"
-                         }`}
-               onClick={() => handleCategoryClick(item)}
-             >
-               {item.name}
-             </button>
-           ))}
-         </div>
-       </div>
-     </div>
-   </nav>
- );
+    setActiveItem(item.name);
+    const newPath =
+      item.code === "ALL"
+        ? "/list?page=1"
+        : `/list?category=${item.code}&page=1`;
+
+    navigate(newPath);
+  };
+
+  return (
+    <nav className="w-full bg-white border-b border-gray-200 overflow-x-auto">
+      <div className="max-w-7xl mx-auto px-4 md:px-6">
+        <div className="flex justify-start items-center h-16 md:h-14">
+          <div className="flex gap-12 md:gap-8 sm:gap-2 whitespace-nowrap">
+            {menuItems.map((item) => (
+              <button
+                key={item.name}
+                className={`relative px-3 py-2 md:py-1.5 text-sm md:text-[15px] sm:text-xs font-medium
+                          transition-colors duration-200 border-0 bg-transparent cursor-pointer shrink-0
+                          ${
+                            activeItem === item.name
+                              ? 'text-yellow-300 after:content-[""] after:absolute after:bottom-[-1px] after:left-0 after:w-full after:h-0.5 after:bg-yellow-300'
+                              : "hover:text-yellow-300"
+                          }`}
+                onClick={() => handleCategoryClick(item)}
+              >
+                {item.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
 };
 
 export default Category;

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -5,6 +5,7 @@ import { useLocation } from "react-router-dom";
 import { Outlet } from "react-router-dom";
 import TopButton from "@components/layout/TopButton";
 import RestoreWishList from "@components/RestoreWishList";
+import ChannelTalk from "@components/ChannelTalk"; 
 
 export default function Layout() {
   const location = useLocation();
@@ -19,6 +20,8 @@ export default function Layout() {
           <Category />
         </>
       )}
+
+      <ChannelTalk />
 
       <Outlet />
       <RestoreWishList />


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
## 카테고리 컴포넌트 뒤로가기 안되는 버그
네비게이션 시 replace: true 옵션 삭제 페이지네이션이나 필터링 시 히스토리가 너무 많이 쌓이면 안좋다고 해서 사용했는데 히스토리가 안남아서 뒤로가기가 안될 줄은 몰랐다. ㅎㅎ;;

##  페이지 이동 시 채널톡이 깜빡이는 버그
원래는 브라우저의 History API를 사용하여 특정페이지에 들어갔을 때 채널톡 버튼이 사라지게 만들었음
근데 문제점이 페이지 이동마다 채널톡을 재초기화해서 깜빡임이 발생함
그래서 react의 useLocation를 사용 -> 채널톡을 한 번만 초기화하고 show/hide로 제어해서 깜빡임 없음
하지만 useLocation은 RouterProvider내부에서만 사용가능하기에 원래 app.jsx에 있던 채널톡 컴포넌트를 components/layout/index.jsx 파일로 이동 
![image](https://github.com/user-attachments/assets/a1fc6998-34c8-4fae-bef4-446ef68eea0f)
- location.pathname이 변경될 때마다 실행 (페이지 이동 시)
- 현재 페이지가 관리자/로그인/회원가입 페이지인지 확인
- 해당 페이지에 따라 채널톡 버튼을 숨기거나 보여줌

### 채널톡이 열리지 않은 상태로 로그인/회원/관리자 들어가면 숨김
![image](https://github.com/user-attachments/assets/354d2aa1-ba6d-42a5-b4d0-7f31c1b01be4)
### 채널톡이 열린 상태로 들어가면 열려있음 하지만 채널톡을 닫으면 다시 사라짐
![image](https://github.com/user-attachments/assets/361c6d9a-77c3-4ac2-befd-af3de01528a3)



- 페이지 이동 시 채널톡을 재로딩하지 않고 버튼만 숨기거나 보여줌
- 결과적으로 깜빡임 없이 부드럽게 동작됨


## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #133 
