### PR TITLE
[BUGFIX] 상품 리스트 페이지에서 다른 카테고리로 이동할 때는 정렬 옵션이 초기화되지 않는 버그 픽스

### DIFF
--- a/src/pages/product/List.jsx
+++ b/src/pages/product/List.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import useAxiosInstance from "@hooks/useAxiosInstance";
 import { useQuery } from "@tanstack/react-query";
@@ -40,6 +40,17 @@ export default function List() {
 
   // 현재 카테고리명 찾기
   const currentCategory = CATEGORY_MAP[category] || "전체상품";
+
+  // 카테고리가 변경될 때마다 정렬 옵션을 초기화하는 useEffect 추가
+  useEffect(() => {
+    if (queryStr.get("sort")) {
+      setSortOption(queryStr.get("sort"));
+    } else {
+      setSortOption("등록순");
+    }
+    setIsOpen(false);
+  }, [category]);
+
 
   // 상품 데이터 가져오기
   const { data, isLoading } = useQuery({
@@ -88,8 +99,10 @@ export default function List() {
 
   // 정렬 옵션 클릭 핸들러
   const handleSortClick = option => {
-    setSortOption(option); // 선택된 정렬 옵션 업데이트
+    setSortOption(option);
     setIsOpen(false);
+    // 현재 페이지를 1로 리셋하고 정렬 옵션 변경
+    navigate(`/list?category=${category}&page=1&sort=${option}`);
   };
 
   const products = data.item.map(item => ({


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
리스트페이지에서 다른 카테고리로 이동하면 정렬 옵션 초기화
새로고침하면 기존의 정렬 옵션 유지 

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #178 
